### PR TITLE
Change `script` to `unsupported_script`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 - id: format-justfile
   name: Format Justfiles
-  language: script
+  language: unsupported_script
   entry: pre-commit-just.sh
   files: '\.?[jJ]ustfile'


### PR DESCRIPTION
The pre-commit folks have apparently deprecated the use of a bare `script` as a language.