### PR TITLE
chore: bump actions/checkout to v7

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - uses: actions/setup-python@v3
     - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - uses: extractions/setup-just@v2
     - run: ./tests/run.sh


### PR DESCRIPTION
`actions/checkout@v3` runs on the deprecated Node 16 runtime. [Node 20 is now EOL too](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), so bump both workflows to [`v7`](https://github.com/actions/checkout/releases) (Node 24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)